### PR TITLE
Catch mandatory messages when unroutable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@
 serviceName := $(shell basename `pwd`)
 
 test:
-	NODE_ENV=test ./node_modules/.bin/mocha "test/**/*.js" --exit
+	NODE_ENV=test ./node_modules/.bin/mocha "test/**/*.js" "**/*.spec.js" --exit
 
 cover:
-	NODE_ENV=test ./node_modules/.bin/nyc -x "test/*" --reporter=lcov --reporter=text-lcov ./node_modules/.bin/mocha --timeout 5000 "test/**/*.js" "src/**/*.js" --exit
+	NODE_ENV=test ./node_modules/.bin/nyc -x "test/*" -x "**/*.spec.js" --reporter=lcov --reporter=text-lcov ./node_modules/.bin/mocha --timeout 5000 "test/**/*.js" "src/**/*.js" --exit
 
 lint:
 	./node_modules/.bin/eslint index.js plugins lib

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -5,7 +5,30 @@ class TimeoutError extends Error {
     }
 }
 
+class BounceError extends Error {
+    constructor(detail, msg) {
+        const { fields: { replyText, exchange, routingKey } = {} } = msg || {};
+        const ex = exchange === '' ? '(default)' : exchange;
+        super(`${detail} Code: ${replyText}, Exchange: ${ex}, Routing Key: ${routingKey}`);
+        this.msg = msg;
+    }
+}
+
+class UndeliverableMessageError extends BounceError {
+    constructor(msg) {
+        super('Message undeliverable immediately:', msg);
+    }
+}
+
+class UnroutableMessageError extends BounceError {
+    constructor(msg) {
+        super('Message unroutable:', msg);
+    }
+}
+
 module.exports = {
     TimeoutError,
+    UnroutableMessageError,
+    UndeliverableMessageError,
     isFatal: require('./client').isFatalError
 };

--- a/plugins/confirm.js
+++ b/plugins/confirm.js
@@ -1,0 +1,58 @@
+const { EventEmitter } = require('events');
+const Plugin = require('./base');
+const { Scopes: { CHANNEL, PUBLICATION } } = require('../lib/constants');
+const { UnroutableMessageError, UndeliverableMessageError } = require('../lib/errors');
+
+const Puid = require('puid');
+
+module.exports = class extends Plugin {
+
+    constructor({ uid = new Puid() } = {}) {
+        super();
+        this.uid = uid;
+        this._failed = new EventEmitter();
+        this.wrappers = {
+            [CHANNEL]: this.handleBounced.bind(this),
+            [PUBLICATION]: this.mandate.bind(this)
+        };
+    }
+
+    handleBounced() {
+        return (create) => () => {
+            return create()
+                .then((ch) => {
+                    ch.on('return', (msg) => {
+                        if (msg.properties.messageId) {
+                            this._failed.emit(msg.properties.messageId, msg);
+                        }
+                    });
+                    return ch;
+                });
+        };
+    }
+
+    mandate() {
+        return (publish) =>
+            (ex, key, content, options, cb) => {
+                const {
+                    mandatory,
+                    immediate,
+                    messageId = this.uid.generate()
+                } = options;
+                if (mandatory || immediate) {
+                    // `immediate` option is not implemented on RabbitMQ
+                    const listener = (msg) => {
+                        const err = mandatory ? new UnroutableMessageError(msg) :
+                            new UndeliverableMessageError(msg);
+                        // this works since basic.return's are sent before basic.ack's
+                        // c.f. https://www.rabbitmq.com/confirms.html#when-publishes-are-confirmed
+                        cb(err);
+                        this._failed.removeListener(messageId, listener);
+                    };
+                    this._failed.on(messageId, listener);
+                }
+                return publish(ex, key, content, { ...options, messageId }, cb);
+            };
+    }
+
+};

--- a/plugins/confirm.spec.js
+++ b/plugins/confirm.spec.js
@@ -1,0 +1,26 @@
+const { Client, errors: { UnroutableMessageError } } = require('..');
+const Confirm = require('./confirm');
+
+describe('confirm plugin', () => {
+    let client;
+
+    beforeEach(() => {
+        return new Client('amqp://guest:guest@127.0.0.1:5672', {
+            plugins: [new Confirm()]
+        })
+            .start()
+            .then((cli) => client = cli);
+    });
+
+    afterEach(() => client.close());
+
+    it('should fail a publish when unroutable', (done) => {
+        const opts = { mandatory: true };
+        client.publish('non.existent', Buffer.from('hello'), opts)
+            .then(() => done(new Error('Unroutable message does not fail')))
+            .catch((err) => {
+                if (err instanceof UnroutableMessageError) done();
+                else done(new Error('Reason does not match'));
+            });
+    });
+});

--- a/plugins/index.js
+++ b/plugins/index.js
@@ -4,5 +4,6 @@ module.exports = {
     Reconnection: require('./recover'),
     Duplex: require('./duplex'),
     Encoding: require('./encoding'),
-    RPC: require('./rpc')
+    RPC: require('./rpc'),
+    Confirm: require('./confirm')
 };


### PR DESCRIPTION
The new plugin completes the RabbitMQ's publisher confirms feature, by handling unrouted messages.

However it does not support, for example, retries or alternate routing on failures for it would depend on the server topology of users.

@PuKoren @robjweiss 