### PR TITLE
Support easy configuration of DLX

### DIFF
--- a/plugins/dlx.js
+++ b/plugins/dlx.js
@@ -17,21 +17,17 @@ module.exports = class extends Plugin {
             durable: true,
             ...options
         };
-        super();
-        this.wrappers = {
-            [CHANNEL]({ logger }) {
-                return (create) => () => create()
-                    .then((ch) => {
-                        return ch
-                            .assertExchange(name, type, options)
-                            .then(() => associateDlx(ch, name))
-                            .catch((err) => {
-                                logger.error('[AMQP:dlx] Initial assertions failed:', err);
-                                return ch;
-                            });
+        super('dlx');
+        this.scopes[CHANNEL] = (create) => () => create()
+            .then((ch) => {
+                return ch
+                    .assertExchange(name, type, options)
+                    .then(() => associateDlx(ch, name))
+                    .catch((err) => {
+                        this.logger.error('[AMQP:dlx] Initial assertions failed:', err);
+                        return ch;
                     });
-            }
-        };
+            });
     }
 
 };

--- a/plugins/dlx.js
+++ b/plugins/dlx.js
@@ -1,0 +1,37 @@
+const Plugin = require('./base');
+const { Scopes: { API, CHANNEL } } = require('../lib/constants');
+
+const associateDlx = (ch, name) => {
+    const _assert = ch.assertQueue;
+    ch.assertQueue = function(queue, options) {
+        options = { deadLetterExchange: name, ...options };
+        return _assert.call(ch, queue, options);
+    };
+    return ch;
+};
+
+module.exports = class extends Plugin {
+
+    constructor({ name = 'dlx', type = 'topic', options = {} } = {}) {
+        options = {
+            durable: true,
+            ...options
+        };
+        super();
+        this.wrappers = {
+            [CHANNEL]({ logger }) {
+                return (create) => () => create()
+                    .then((ch) => {
+                        return ch
+                            .assertExchange(name, type, options)
+                            .then(() => associateDlx(ch, name))
+                            .catch((err) => {
+                                logger.error('[AMQP:dlx] Initial assertions failed:', err);
+                                return ch;
+                            });
+                    });
+            }
+        };
+    }
+
+};

--- a/plugins/dlx.js
+++ b/plugins/dlx.js
@@ -1,5 +1,5 @@
 const Plugin = require('./base');
-const { Scopes: { API, CHANNEL } } = require('../lib/constants');
+const { Scopes: { CHANNEL } } = require('../lib/constants');
 
 const associateDlx = (ch, name) => {
     const _assert = ch.assertQueue;

--- a/plugins/dlx.spec.js
+++ b/plugins/dlx.spec.js
@@ -1,0 +1,46 @@
+const { Client } = require('..');
+const DeadLetter = require('./dlx');
+
+describe('dlx plugin', () => {
+    let client;
+
+    const options = {
+        exchange: {
+            name: 'dlx',
+            topic: '#',
+            options: {
+                autoDelete: true
+            }
+        }
+    };
+
+    beforeEach(() => {
+        return new Client('amqp://guest:guest@127.0.0.1:5672', {
+            plugins: [new DeadLetter(options)]
+        })
+            .start()
+            .then((cli) => client = cli);
+    });
+
+    afterEach(() => client && client.close());
+
+    it('should dead-letter nack\'d messages', (done) => {
+        client
+            .exchange('dlx')
+            .queue('deadLetters', { exclusive: true, noAck: true, deadLetterExchange: null })
+            .subscribe('#', (msg) => {
+                if (msg.fields.routingKey === 'key'
+                    && msg.properties.headers['x-first-death-exchange'] === '') {
+                    done();
+                } else {
+                    done(new Error('Message routed differently'));
+                }
+            })
+            .then(() => client
+                .subscribe('key', (msg) => {
+                    msg.nack(false, false);
+                }))
+            .then(() => client.publish('key', Buffer.from('hello')))
+            .catch(done);
+    });
+});


### PR DESCRIPTION
This drafted plugin:
- Creates a default dead-letter exchange
- For newly created queues, set the above as `x-dead-letter-exchange` (so messages will be sent there when stuck in the queue)

But does not:
- Create nor bind any queue to it, meaning letters are lost by default

Users have to be careful when binding a queue to the exchange, which typically requires unsetting `x-dead-letter-exchange`, not to create any infinite loop.

(So it might not be very useful altogether, I'd admit)

@PuKoren @robjweiss 