### PR TITLE
Wait for confirmation before closing the channel

### DIFF
--- a/test/topic.spec.js
+++ b/test/topic.spec.js
@@ -16,14 +16,14 @@ describe('topic', function() {
                 msg.ack();
 
                 if (content[1] === 'message') {
-                    done();
+                    confirmed.then(() => done());
                 } else {
                     done(new Error("Message not carried properly"));
                 }
             })
             .catch(done);
 
-        client.start()
+        const confirmed = client.start()
             .then(() => client.type('topic')
                 .publish('routing.key.1', Buffer.from(JSON.stringify({ 1: 'message' }))))
             .catch(done);
@@ -44,7 +44,7 @@ describe('topic', function() {
                 msg.ack();
 
                 if (calls === 2) {
-                    done();
+                    confirmed.then(() => done());
                 } else if (calls === 3) {
                     done(new Error("Message received more than twice"));
                 }
@@ -55,7 +55,7 @@ describe('topic', function() {
             .subscribe('routing.key.#', process(1)).catch(done);
 
 
-        client.start()
+        const confirmed = client.start()
             .then(() => client.type('topic').publish('routing.key.1', Buffer.from("1")))
             .then(() => client.type('topic').publish('routing.key.2', Buffer.from("1")))
             .catch(done);
@@ -75,7 +75,7 @@ describe('topic', function() {
                 msg.ack();
 
                 if (calls === 4) {
-                    done();
+                    confirmed.then(() => done());
                 } else if (calls === 2) {
                     done(new Error("Message received twice on the first subscriber"));
                 } else if (calls === 6) {
@@ -90,7 +90,7 @@ describe('topic', function() {
             .subscribe('routing.key.#', process(3)).catch(done);
 
 
-        client.start()
+        const confirmed = client.start()
             .then(() => client.type('topic').publish('routing.key.1', Buffer.from("1")))
             .catch(done);
     });


### PR DESCRIPTION
Fixes random failures in the test suites, being caused by the `publish()`es throwing an exception due to the connection closing before confirmation.

This can be fixed by either waiting for the confirmation, or using the channels without publisher confirms turned on. This branch depicts the first approach.

But in the users perspective, one should be able to choose the channel class, so I will probably close this PR and provide a way to override the behavior :thinking: 