### PR TITLE
Chore/typecheck

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,21 @@ jobs:
           name: Run ESLint
           command: make lint
 
+  typecheck:
+    docker:
+      - image: node:13-alpine
+    steps:
+      - checkout
+      - *restore
+      - *make
+      - run:
+          name: Install Dependencies
+          command: make deps
+      - *cache
+      - run:
+          name: Type Check
+          command: make types
+
   node8:
     docker:
       - image: node:8-alpine
@@ -124,24 +139,27 @@ workflows:
   build:
     jobs:
       - lint
+      - typecheck:
+          requires:
+            - lint
       - node8:
           requires:
-            - lint
+            - typecheck
       - node10:
           requires:
-            - lint
+            - typecheck
       - node11:
           requires:
-            - lint
+            - typecheck
       - node12:
           requires:
-            - lint
+            - typecheck
       - node14:
           requires:
-            - lint
+            - typecheck
       - coverage:
           requires:
-            - lint
+            - typecheck
       - report_coverage:
           requires:
             - coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,26 +139,30 @@ workflows:
   build:
     jobs:
       - lint
-      - typecheck:
-          requires:
-            - lint
+      - typecheck
       - node8:
           requires:
+            - lint
             - typecheck
       - node10:
           requires:
+            - lint
             - typecheck
       - node11:
           requires:
+            - lint
             - typecheck
       - node12:
           requires:
+            - lint
             - typecheck
       - node14:
           requires:
+            - lint
             - typecheck
       - coverage:
           requires:
+            - lint
             - typecheck
       - report_coverage:
           requires:

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# Type difinitions
+types/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #!make
 
-.PHONY: deps test coverage lint lint-fix
+.PHONY: deps test coverage lint lint-fix types
 
 NPM_BIN = ./node_modules/.bin
 export NODE_ENV ?= test
@@ -21,3 +21,6 @@ lint:
 
 lint-fix:
 	@$(NPM_BIN)/eslint index.js plugins lib --fix
+
+types:
+	@$(NPM_BIN)/tsc -p .

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports.connect = (url, options) => Client.start(url, {
 });
 
 module.exports.Client = function(url, { plugins = [], ...options } = {}) {
-    return new Client(url, { plugins: resolvePlugins(plugins), ...options });
+    return Client(url, { plugins: resolvePlugins(plugins), ...options });
 };
 
 module.exports.Client.start = function(url, { plugins = [], ...options } = {}) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,31 @@
+//
+// Imports
+//
+
 const Client = require('./lib');
 const plugins = require('./plugins');
 
+
+//
+// Types
+//
+
+/**
+ * @typedef { import("./lib").Client } Client
+ * @typedef { import("./lib").Plugin } Plugin
+ * @typedef { import("./lib").Options & { plugins?: (Plugin | string)[] }} Options
+ */
+
+
+//
+// Plugins
+//
+
+/**
+ * @type {{ [key: string]: { new(): Plugin } }}
+ */
 const Plugins = {
-    gracefulShutdown: plugins.ConnectionRetry,
+    gracefulShutdown: plugins.GracefulShutdown,
     connectionRetry: plugins.ConnectionRetry,
     duplex: plugins.Duplex,
     encoding: plugins.Encoding,
@@ -11,14 +34,28 @@ const Plugins = {
     retry: plugins.Retry
 };
 
+/**
+ * @param {(Plugin | string)[]} plugins
+ * @return {Plugin[]}
+ */
 const resolvePlugins = (plugins) => plugins
     .filter(Boolean)
     .map((plugin) => {
-        if (typeof plugin === 'string' && Plugins[plugin]) {
+        if (typeof plugin === 'string') {
             return new Plugins[plugin]();
         } else return plugin;
     });
 
+
+//
+// Exports
+//
+
+/**
+ * @param {string | object} [url]
+ * @param {object} [options]
+ * @return {Promise<Client>}
+ */
 module.exports.connect = (url, options) => Client.start(url, {
     logger: console,
     plugins: resolvePlugins([
@@ -33,10 +70,20 @@ module.exports.connect = (url, options) => Client.start(url, {
     ...options
 });
 
+/**
+ * @param {string | object} [url]
+ * @param {Options} [options]
+ * @return {Client}
+ */
 module.exports.Client = function(url, { plugins = [], ...options } = {}) {
     return Client(url, { plugins: resolvePlugins(plugins), ...options });
 };
 
+/**
+ * @param {string | object} [url]
+ * @param {Options} [options]
+ * @return {Promise<Client>}
+ */
 module.exports.Client.start = function(url, { plugins = [], ...options } = {}) {
     return Client.start(url, { plugins: resolvePlugins(plugins), ...options });
 };

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ const plugins = require('./plugins');
 //
 
 /**
- * @typedef { import("./lib").Client } Client
- * @typedef { import("./lib").Plugin } Plugin
- * @typedef { import("./lib").Options & { plugins?: (Plugin | string)[] }} Options
+ * @typedef {import('./lib').Client} Client
+ * @typedef {import('./lib').Plugin} Plugin
+ * @typedef {import('./lib').Options & { plugins?: (Plugin | string)[] }} Options
  */
 
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -25,10 +25,10 @@ const exchangeTypes = Object.values(ExchangeTypes);
 //
 
 /**
- * @typedef { import("./client").Channel & import("./client").ConfirmChannel } Channel
- * @typedef { import("amqplib").Message } Message
- * @typedef { import("amqplib").ConsumeMessage } ConsumeMessage
- * @typedef { import("amqplib").Replies.Empty } EmptyReply
+ * @typedef {import('./client').Channel & import('./client').ConfirmChannel} Channel
+ * @typedef {import('amqplib').Message} Message
+ * @typedef {import('amqplib').ConsumeMessage} ConsumeMessage
+ * @typedef {import('amqplib').Replies.Empty} EmptyReply
  */
 
 /**
@@ -43,7 +43,7 @@ const exchangeTypes = Object.values(ExchangeTypes);
  */
 
 /**
- * @typedef { import("./types").Logger } Logger
+ * @typedef {import('./types').Logger} Logger
  * @typedef {{
  *   logger: Logger,
  *   abort: (reason: Error) => void,

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,7 +2,11 @@
 // Imports
 //
 
+/**
+ * @type {(value: any, message?: string) => asserts value}
+ */
 const assert = require('assert');
+
 const { EventEmitter } = require('events');
 const defaults = require('./defaults');
 const { ExchangeTypes } = require('./constants');
@@ -17,13 +21,63 @@ const exchangeTypes = Object.values(ExchangeTypes);
 
 
 //
+// Types
+//
+
+/**
+ * @typedef { import("amqplib").ConfirmChannel } Channel
+ * @typedef { import("amqplib").Message } Message
+ * @typedef { import("amqplib").ConsumeMessage } ConsumeMessage
+ * @typedef { import("amqplib").Replies.Empty } EmptyReply
+ */
+
+/**
+ * @typedef {{ exchange: string, queue: string, assert: boolean }} Context
+ * @typedef {{ consumerTag: string, consumer: EventEmitter }} Consumer
+ */
+
+/**
+ * @callback Handler
+ * @param {ConsumeMessage | null} msg
+ * @return {any}
+ */
+
+/**
+ * @typedef {(msg: any, ...params: any[]) => void} LogMethod
+ * @typedef {{
+ *   info: LogMethod,
+ *   warn: LogMethod,
+ *   error: LogMethod,
+ *   debug: LogMethod
+ * }} Logger
+ */
+
+/**
+ * @typedef {{
+ *   logger: Logger,
+ *   abort: (reason: Error) => void,
+ *   _assert: {<T>(assertion: (ch: Promise<Channel>) => Promise<T>): Promise<T>},
+ *   _asserted: () => Promise<Channel>
+ *   _self: typeof ContextChannel
+ * }} ClientProperties
+ */
+
+
+//
 // API class
 //
 
-// class to hold a certain context about to what exchange/queue
-// to publish or consume messages
+/**
+ * Class to hold a certain context about to what exchange/queue
+ * to publish or consume messages.
+ */
 class ContextChannel {
 
+    /**
+     * @constructor
+     * @param {Context | null} context
+     * @param {ClientProperties} properties
+     */
     constructor(context, {
         logger,
         abort,
@@ -39,32 +93,59 @@ class ContextChannel {
         };
 
         // add readonly properties
-        Object.entries({
-            logger,
-            abort,
-            _assert,
-            _asserted,
-            _self
-        }).forEach(([key, value]) => Object.defineProperty(this, key, { value }));
+
+        /** @readonly */
+        this.logger = logger;
+        /** @readonly */
+        this.abort = abort;
+        /** @readonly */
+        this._assert = _assert;
+        /** @readonly */
+        this._asserted = _asserted;
+        /** @readonly */
+        this._self = _self;
     }
 
-    // an alias for the pre-defined exchanges
+    /**
+     * Alias for the pre-defined exchanges
+     *
+     * @param {string} type
+     */
     type(type) {
         return this.exchange(null, type);
     }
 
+    /**
+     * Enable/Disable assertions of exchanges and queues.
+     *
+     * @param {boolean} assert
+     * @return {ContextChannel}
+     */
     assert(assert = true) {
         return this.context({ assert });
     }
 
-    context({ assert }) {
+    /**
+     * Enable/Disable assertions of exchanges and queues.
+     *
+     * @param {Partial<Context>} context
+     * @return {ContextChannel}
+     */
+    context(context) {
         return new this._self({
             ...this._context,
-            assert
+            ...context
         }, this);
     }
 
-    // assert or refer to an exchange
+    /**
+     * Assert or refer to an exchange.
+     *
+     * @param {string | null} name
+     * @param {string} [type]
+     * @param {object} [options]
+     * @return {ContextChannel}
+     */
     exchange(name, type, options) {
         assert(name || type,
             'ContextChannel.exchange() requires either `name` or `type`');
@@ -73,17 +154,21 @@ class ContextChannel {
             `Exchange type ${type} not valid`);
 
         const { assert: _assertion } = this._validateContext();
-        const assertion = name && type && _assertion;
+        const assertion = _assertion &&
+            typeof name === 'string' &&
+            typeof type === 'string';
 
         // when the name is not specified, use default exchange for each type
-        name = name === null && type ?
-            defaults.resolveExchange(type) : name;
+        const _name = name === null && type ?
+            defaults.resolveExchange(type) : name || '';
+        const _type = type || 'direct';
 
+        /** @type {(ch: Channel) => Promise<{ exchange: string }>} */
         const assertExchange = assertion ?
             // assert the specified exchange
-            (ch) => ch.assertExchange(name, type, options) :
+            (ch) => ch.assertExchange(_name, _type, options) :
             // no need for that when it is a default exchange
-            (ch) => ch.checkExchange(name);
+            (ch) => ch.checkExchange(_name);
 
         this._assert(channel => channel
             .then(assertExchange)
@@ -96,7 +181,7 @@ class ContextChannel {
             })
             .catch((err) => {
                 this.logger.error(
-                    `[AMQP] Assertion for exchange ${type}/${name} failed.`,
+                    `[AMQP] Assertion for exchange ${type}/${_name} failed.`,
                     err.message);
                 // assertion error should destroy the connection
                 this.abort(err);
@@ -106,15 +191,21 @@ class ContextChannel {
         // create a new context with the exchange
         return new this._self({
             ...this._context,
-            exchange: name
+            exchange: _name
         }, this);
     }
 
-    // assert or refer to a queue
+    /**
+     * Assert or refer to a queue.
+     *
+     * @param {string} name
+     * @param {object} [options]
+     * @return {ContextChannel}
+     */
     queue(name, options) {
         const { assert: assertion } = this._validateContext();
         this._assert(channel => channel
-            .then((ch) => assert ?
+            .then((ch) => assertion ?
                 ch.assertQueue(name, options) : ch.checkQueue(name))
             .then(({ queue: q }) => {
                 this.logger.debug(`[AMQP] Queue ${q} ${assertion ? 'asserted' : 'checked'}.`);
@@ -134,7 +225,11 @@ class ContextChannel {
         }, this);
     }
 
-    // verify and format the context to publish/consume messages
+    /**
+     * Verify and format the context to publish/consume messages.
+     *
+     * @return {Context}
+     */
     _validateContext() {
         let { queue, exchange } = this._context;
         if (exchange === '' && queue !== '') {
@@ -143,12 +238,26 @@ class ContextChannel {
         return this._context = { ...this._context, queue, exchange };
     }
 
-    // an alias for consume()
-    subscribe() {
-        return this.consume.apply(this, arguments);
+    /**
+     * Alias for consume().
+     *
+     * @param {string | object} binding
+     * @param {Handler} fn
+     * @param {object} [options]
+     * @return {Promise<Consumer>}
+     */
+    subscribe(binding, fn, options) {
+        return this.consume.call(this, binding, fn, options);
     }
 
-    // bind a queue to an exchange and start consuming
+    /**
+     * Bind a queue to an exchange and start consuming.
+     *
+     * @param {string | object} binding
+     * @param {Handler} fn
+     * @param {object} [options]
+     * @return {Promise<Consumer>}
+     */
     consume(binding, fn, options) {
         // allow to omit the binding key for use with fanout exchanges
         if (arguments.length === 1) return this.consume('', fn);
@@ -159,6 +268,7 @@ class ContextChannel {
 
         const { queue, exchange, assert: assertion } = this._validateContext();
 
+        /** @type {(ch: Promise<Channel>) => Promise<{ ch: Channel, queue: string }>} */
         let bind;
         const opts = defaults.options.anonymousQueue;
 
@@ -181,9 +291,10 @@ class ContextChannel {
                     return fallbackQueue.then((q) => ({ ch, queue: q }));
                 })
                 .then(({ ch, queue }) => {
-                    const args = typeof binding === 'string' ?
-                        [queue, exchange, binding] : [queue, exchange, '', binding];
-                    return ch.bindQueue(...args).then(() => ({ ch, queue }));
+                    const bind = typeof binding === 'string' ?
+                        ch.bindQueue(queue, exchange, binding) :
+                        ch.bindQueue(queue, exchange, '', binding);
+                    return bind.then(() => ({ ch, queue }));
                 });
         }
 
@@ -192,11 +303,20 @@ class ContextChannel {
             .then(({ ch, queue }) => this._consume(ch, queue, fn, options)));
     }
 
+    /**
+     * @param {Channel} ch
+     * @param {string} queue
+     * @param {Handler} fn
+     * @param {object} [options]
+     * @return Promise<Consumer>
+     */
     _consume(ch, queue, fn, options) {
         // provides a way to debug errors
         const emitter = new EventEmitter();
+        /** @type {string} */
         let tag;
         const handler = (msg) => {
+            if (!msg) return fn(msg);
             // wrap (possibly sync.) handler in a promise.
             return Promise.resolve()
                 .then(() => fn(Object.assign(msg, {
@@ -219,18 +339,32 @@ class ContextChannel {
                 Object.assign(consumer, { consumer: emitter }));
     }
 
+    /**
+     * Stop delivering to the consumer.
+     *
+     * @param {string} consumerTag
+     * @return {Promise<EmptyReply>}
+     */
     cancel(consumerTag) {
         return this._asserted()
             .then((ch) => ch.cancel(consumerTag));
     }
 
-    // publish a message with the specified routing key
+    /**
+     * Publish a message with the specified routing key.
+     *
+     * @param {string} routingKey
+     * @param {Buffer} content
+     * @param {object} [options]
+     * @return {Promise<boolean>}
+     */
     publish(routingKey, content, options = {}) {
         const { exchange } = this._validateContext();
         return this._asserted()
             .then((ch) => {
                 const confirmMode = typeof ch.waitForConfirms === 'function';
                 return new Promise((resolve, reject) => {
+                    /** @type {(err: Error) => void} */
                     const cb = (err) => err ? reject(err) : resolve();
                     try {
                         const ok = ch.publish(exchange, routingKey, content, options, cb);

--- a/lib/api.js
+++ b/lib/api.js
@@ -25,7 +25,7 @@ const exchangeTypes = Object.values(ExchangeTypes);
 //
 
 /**
- * @typedef { import("amqplib").ConfirmChannel } Channel
+ * @typedef { import("./client").Channel & import("./client").ConfirmChannel } Channel
  * @typedef { import("amqplib").Message } Message
  * @typedef { import("amqplib").ConsumeMessage } ConsumeMessage
  * @typedef { import("amqplib").Replies.Empty } EmptyReply
@@ -43,23 +43,14 @@ const exchangeTypes = Object.values(ExchangeTypes);
  */
 
 /**
- * @typedef {(msg: any, ...params: any[]) => void} LogMethod
- * @typedef {{
- *   info: LogMethod,
- *   warn: LogMethod,
- *   error: LogMethod,
- *   debug: LogMethod
- * }} Logger
- */
-
-/**
+ * @typedef { import("./types").Logger } Logger
  * @typedef {{
  *   logger: Logger,
  *   abort: (reason: Error) => void,
  *   _assert: {<T>(assertion: (ch: Promise<Channel>) => Promise<T>): Promise<T>},
  *   _asserted: () => Promise<Channel>
  *   _self: typeof ContextChannel
- * }} ClientProperties
+ * }} ChannelProperties
  */
 
 
@@ -76,7 +67,7 @@ class ContextChannel {
     /**
      * @constructor
      * @param {Context | null} context
-     * @param {ClientProperties} properties
+     * @param {ChannelProperties} properties
      */
     constructor(context, {
         logger,
@@ -107,7 +98,7 @@ class ContextChannel {
     }
 
     /**
-     * Alias for the pre-defined exchanges
+     * Alias for the pre-defined exchanges.
      *
      * @param {string} type
      */
@@ -262,9 +253,8 @@ class ContextChannel {
         // allow to omit the binding key for use with fanout exchanges
         if (arguments.length === 1) return this.consume('', fn);
 
-        assert(typeof binding === 'string'
-            || binding && typeof binding === 'object',
-        'Binding key or object not valid');
+        assert(typeof binding === 'string' || binding &&
+            typeof binding === 'object', 'Binding key or object not valid');
 
         const { queue, exchange, assert: assertion } = this._validateContext();
 
@@ -273,6 +263,7 @@ class ContextChannel {
         const opts = defaults.options.anonymousQueue;
 
         if (exchange === '') {
+            assert(typeof binding === 'string');
             // using the default exchange
             // (messages are sent to a queue with name same as the binding key)
             bind = (ch) => ch
@@ -315,6 +306,7 @@ class ContextChannel {
         const emitter = new EventEmitter();
         /** @type {string} */
         let tag;
+        /** @type {Handler} */
         const handler = (msg) => {
             if (!msg) return fn(msg);
             // wrap (possibly sync.) handler in a promise.

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,11 @@ module.exports = {
     isFatalError
 };
 
+/**
+ * Logged amqp.connect()
+ *
+ * @this {{ logger: any }}
+ */
 function logCreateChannel(conn, name) {
     const logger = this.logger;
     const create = conn[name];
@@ -38,7 +43,11 @@ function logCreateChannel(conn, name) {
     };
 }
 
-// logged amqp.connect()
+/**
+ * Logged amqp.connect()
+ *
+ * @this {{ logger: any }}
+ */
 function connect(url, socketOptions) {
     const logger = this.logger;
     logger.debug('[AMQP] Connecting to server...');

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,22 +1,62 @@
+//
+// Imports
+//
+
 const amqp = require('amqplib');
+// @ts-ignore
 const { isFatalError } = require('amqplib/lib/connection');
 
-module.exports = {
-    connect,
-    isFatalError
-};
+
+//
+// Types
+//
 
 /**
- * Logged amqp.connect()
- *
- * @this {{ logger: any }}
+ * @template T, U
+ * @typedef {Pick<T, Exclude<keyof T, keyof U>> & U} Override
  */
-function logCreateChannel(conn, name) {
-    const logger = this.logger;
-    const create = conn[name];
-    return conn[name] = function() {
+/**
+ * @typedef { import("events").EventEmitter } EventEmitter
+ * @typedef {{
+ *   ch: number,
+ *   consume: (...args: Parameters<import("amqplib").Channel['consume']>) => Promise<import("amqplib").Replies.Consume>,
+ * }} WrappedChannel
+ * @typedef { Omit<import("amqplib").Channel, 'consume'> & WrappedChannel } Channel
+ * @typedef { Omit<import("amqplib").ConfirmChannel, 'consume'> & WrappedChannel } ConfirmChannel
+ * @typedef { import("amqplib").Options.Connect } ConnectOptions
+ *
+ * @typedef { import("events").EventEmitter & {
+ *   close: () => Promise<any>,
+ *   createChannel: () => Promise<Channel>,
+ *   createConfirmChannel: () => Promise<ConfirmChannel>,
+ * } } Connection
+ *
+ * @typedef {Parameters<connect>} ConnectParams
+ * @typedef {Parameters<Connection['createChannel']>} CreateChannelParams
+ * @typedef {Parameters<Channel['publish']>} PublishParams
+ * @typedef {Parameters<Channel['consume']>} SubscribeParams
+ *
+ * @typedef { import("./types").Logger } Logger
+ */
+
+
+//
+// Functions
+//
+
+/**
+ * Logged amqp.createChannel().
+ *
+ * @template {Channel | ConfirmChannel} T
+ * @param {Logger} logger
+ * @param {Connection} conn
+ * @param {() => Promise<T>} create
+ * @return {() => Promise<T>}
+ */
+const logCreateChannel = function(logger, conn, create) {
+    return function() {
         logger.debug('[AMQP] Opening a channel...');
-        const open = create.apply(conn, arguments);
+        const open = create.call(conn);
         return Promise.resolve(open)
             .then((ch) => {
                 const label = `Channel ${ch.ch}`;
@@ -41,14 +81,17 @@ function logCreateChannel(conn, name) {
                 return ch;
             });
     };
-}
+};
 
 /**
- * Logged amqp.connect()
+ * Logged amqp.connect().
  *
- * @this {{ logger: any }}
+ * @this {{ logger: Logger }}
+ * @param {string | ConnectOptions} url
+ * @param {object} [socketOptions]
+ * @return {Promise<Connection>}
  */
-function connect(url, socketOptions) {
+const connect = function(url, socketOptions) {
     const logger = this.logger;
     logger.debug('[AMQP] Connecting to server...');
     const open = amqp.connect(url, socketOptions);
@@ -82,13 +125,27 @@ function connect(url, socketOptions) {
                     err.message);
             });
 
-            logCreateChannel.call(this, conn, 'createChannel');
-            logCreateChannel.call(this, conn, 'createConfirmChannel');
+            const _conn = /** @type {Connection} */ (conn);
 
-            return conn;
+            _conn.createChannel =
+                logCreateChannel(this.logger, _conn, _conn.createChannel);
+            _conn.createConfirmChannel =
+                logCreateChannel(this.logger, _conn, _conn.createConfirmChannel);
+
+            return _conn;
         })
         .catch((err) => {
             logger.error('[AMQP] Connection failed.', err.message);
             throw err;
         });
-}
+};
+
+
+//
+// Exports
+//
+
+module.exports = {
+    connect,
+    isFatalError
+};

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,27 +16,27 @@ const { isFatalError } = require('amqplib/lib/connection');
  * @typedef {Pick<T, Exclude<keyof T, keyof U>> & U} Override
  */
 /**
- * @typedef { import("events").EventEmitter } EventEmitter
+ * @typedef {import('events').EventEmitter} EventEmitter
  * @typedef {{
  *   ch: number,
- *   consume: (...args: Parameters<import("amqplib").Channel['consume']>) => Promise<import("amqplib").Replies.Consume>,
+ *   consume: (...args: Parameters<import('amqplib').Channel['consume']>) => Promise<import('amqplib').Replies.Consume>,
  * }} WrappedChannel
- * @typedef { Omit<import("amqplib").Channel, 'consume'> & WrappedChannel } Channel
- * @typedef { Omit<import("amqplib").ConfirmChannel, 'consume'> & WrappedChannel } ConfirmChannel
- * @typedef { import("amqplib").Options.Connect } ConnectOptions
+ * @typedef {Omit<import('amqplib').Channel, 'consume'> & WrappedChannel} Channel
+ * @typedef {Omit<import('amqplib').ConfirmChannel, 'consume'> & WrappedChannel} ConfirmChannel
+ * @typedef {import('amqplib').Options.Connect} ConnectOptions
  *
- * @typedef { import("events").EventEmitter & {
+ * @typedef {import('events').EventEmitter & {
  *   close: () => Promise<any>,
  *   createChannel: () => Promise<Channel>,
  *   createConfirmChannel: () => Promise<ConfirmChannel>,
- * } } Connection
+ * }} Connection
  *
  * @typedef {Parameters<connect>} ConnectParams
  * @typedef {Parameters<Connection['createChannel']>} CreateChannelParams
  * @typedef {Parameters<Channel['publish']>} PublishParams
  * @typedef {Parameters<Channel['consume']>} SubscribeParams
  *
- * @typedef { import("./types").Logger } Logger
+ * @typedef {import('./types').Logger} Logger
  */
 
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,26 +1,26 @@
-module.exports = {
+/**
+ * Scopes for limiting access by plugins.
+ * Mocking const enums in TS.
+ *
+ * @enum {'connection' | 'channel' | 'publication' | 'subscription' | 'api'}
+ */
+module.exports.Scopes = {
+    CONNECTION: /** @type {'connection'} */ ('connection'),
+    CHANNEL: /** @type {'channel'} */ ('channel'),
+    PUBLICATION: /** @type {'publication'} */ ('publication'),
+    SUBSCRIPTION: /** @type {'subscription'} */ ('subscription'),
+    API: /** @type {'api'} */ ('api')
+};
 
-    /**
-     * Scopes for limiting access by plugins.
-     * @enum {string}
-     */
-    Scopes: {
-        CONNECTION: 'connection',
-        CHANNEL: 'channel',
-        PUBLICATION: 'publication',
-        SUBSCRIPTION: 'subscription',
-        API: 'api'
-    },
-
-    /**
-     * AMQP exchange types.
-     * @enum {string}
-     */
-    ExchangeTypes: {
-        FANOUT: 'fanout',
-        DIRECT: 'direct',
-        TOPIC: 'topic',
-        HEADERS: 'headers'
-    }
-
+/**
+ * AMQP exchange types.
+ *
+ * @readonly
+ * @enum {string}
+ */
+module.exports.ExchangeTypes = {
+    FANOUT: 'fanout',
+    DIRECT: 'direct',
+    TOPIC: 'topic',
+    HEADERS: 'headers'
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,9 @@
 module.exports = {
 
-    // scopes for limiting access by plugins
+    /**
+     * Scopes for limiting access by plugins.
+     * @enum {string}
+     */
     Scopes: {
         CONNECTION: 'connection',
         CHANNEL: 'channel',
@@ -9,7 +12,10 @@ module.exports = {
         API: 'api'
     },
 
-    // exchange types in the AMQP spec
+    /**
+     * AMQP exchange types.
+     * @enum {string}
+     */
     ExchangeTypes: {
         FANOUT: 'fanout',
         DIRECT: 'direct',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -7,6 +7,10 @@ const defaultExchanges = {
     [ExchangeTypes.HEADERS]: 'amq.headers'
 };
 
+/**
+ * @param {ExchangeTypes} type
+ * @return {string}
+ */
 module.exports.resolveExchange = (type) => defaultExchanges[type];
 
 module.exports.options = {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,6 @@
 /**
- * @typedef { import("amqplib").Message } Message
- * @typedef { import("amqplib").MessageFields } MessageFields
+ * @typedef {import('amqplib').Message} Message
+ * @typedef {import('amqplib').MessageFields} MessageFields
  * @typedef {Message & {
  *   fields: MessageFields & {
  *     replyText: string

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,11 +1,30 @@
+/**
+ * @typedef { import("amqplib").Message } Message
+ * @typedef { import("amqplib").MessageFields } MessageFields
+ * @typedef {Message & {
+ *   fields: MessageFields & {
+ *     replyText: string
+ *   }
+ * }} BouncedMessage
+ */
+
 // a semantic error for when an operation is timed out
 module.exports.TimeoutError = class TimeoutError extends Error {
+    /**
+     * @constructor
+     * @param {number} timeout
+     */
     constructor(timeout) {
         super(`Operation timed out after ${timeout}ms`);
     }
 };
 
 module.exports.MessageError = class MessageError extends Error {
+    /**
+     * @constructor
+     * @param {string} text
+     * @param {Message} msg
+     */
     constructor(text, msg) {
         super(text);
         const {
@@ -20,6 +39,9 @@ module.exports.MessageError = class MessageError extends Error {
         this.trace = trace.concat(fields);
         this.originalHeaders = headers;
     }
+    /**
+     * @param {Message} msg
+     */
     static is(msg) {
         return msg.properties.headers[MessageError.keys.error] === true;
     }
@@ -36,29 +58,41 @@ module.exports.MessageError.keys = {
     trace: 'x-error-trace'
 };
 
-class BounceError extends module.exports.MessageError {
-    constructor(detail, msg) {
-        const {
-            fields: {
-                exchange = '(unknown)',
-                replyText = '(unknown)',
-                routingKey = '(unknown)'
-            } = {}
-        } = msg || {};
-        const ex = exchange === '' ? '(default)' : exchange;
-        super(`${detail} Code: ${replyText}, Exchange: ${ex}, Routing Key: ${routingKey}`, msg);
-    }
-}
-
-module.exports.BounceError = BounceError;
+const BounceError = module.exports.BounceError =
+    class BounceError extends module.exports.MessageError {
+        /**
+         * @constructor
+         * @param {string} detail
+         * @param {BouncedMessage} msg
+         */
+        constructor(detail, msg) {
+            const {
+                fields: {
+                    exchange = '(unknown)',
+                    replyText = '(unknown)',
+                    routingKey = '(unknown)'
+                } = {}
+            } = msg || {};
+            const ex = exchange === '' ? '(default)' : exchange;
+            super(`${detail} Code: ${replyText}, Exchange: ${ex}, Routing Key: ${routingKey}`, msg);
+        }
+    };
 
 module.exports.UndeliverableMessageError = class UndeliverableMessageError extends BounceError {
+    /**
+     * @constructor
+     * @param {BouncedMessage} msg
+     */
     constructor(msg) {
         super('Message undeliverable immediately:', msg);
     }
 };
 
 module.exports.UnroutableMessageError = class UnroutableMessageError extends BounceError {
+    /**
+     * @constructor
+     * @param {BouncedMessage} msg
+     */
     constructor(msg) {
         super('Message unroutable:', msg);
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,7 +3,7 @@ module.exports.TimeoutError = class TimeoutError extends Error {
     constructor(timeout) {
         super(`Operation timed out after ${timeout}ms`);
     }
-}
+};
 
 module.exports.MessageError = class MessageError extends Error {
     constructor(text, msg) {
@@ -29,7 +29,7 @@ module.exports.MessageError = class MessageError extends Error {
             [MessageError.keys.trace]: this.trace
         };
     }
-}
+};
 
 module.exports.MessageError.keys = {
     error: 'x-error',
@@ -56,10 +56,10 @@ module.exports.UndeliverableMessageError = class UndeliverableMessageError exten
     constructor(msg) {
         super('Message undeliverable immediately:', msg);
     }
-}
+};
 
 module.exports.UnroutableMessageError = class UnroutableMessageError extends BounceError {
     constructor(msg) {
         super('Message unroutable:', msg);
     }
-}
+};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,11 +1,11 @@
 // a semantic error for when an operation is timed out
-class TimeoutError extends Error {
+module.exports.TimeoutError = class TimeoutError extends Error {
     constructor(timeout) {
         super(`Operation timed out after ${timeout}ms`);
     }
 }
 
-class MessageError extends Error {
+module.exports.MessageError = class MessageError extends Error {
     constructor(text, msg) {
         super(text);
         const {
@@ -31,35 +31,35 @@ class MessageError extends Error {
     }
 }
 
-MessageError.keys = {
+module.exports.MessageError.keys = {
     error: 'x-error',
     trace: 'x-error-trace'
 };
 
-class BounceError extends MessageError {
+class BounceError extends module.exports.MessageError {
     constructor(detail, msg) {
-        const { fields: { replyText, exchange, routingKey } = {} } = msg || {};
+        const {
+            fields: {
+                exchange = '(unknown)',
+                replyText = '(unknown)',
+                routingKey = '(unknown)'
+            } = {}
+        } = msg || {};
         const ex = exchange === '' ? '(default)' : exchange;
         super(`${detail} Code: ${replyText}, Exchange: ${ex}, Routing Key: ${routingKey}`, msg);
     }
 }
 
-class UndeliverableMessageError extends BounceError {
+module.exports.BounceError = BounceError;
+
+module.exports.UndeliverableMessageError = class UndeliverableMessageError extends BounceError {
     constructor(msg) {
         super('Message undeliverable immediately:', msg);
     }
 }
 
-class UnroutableMessageError extends BounceError {
+module.exports.UnroutableMessageError = class UnroutableMessageError extends BounceError {
     constructor(msg) {
         super('Message unroutable:', msg);
     }
 }
-
-module.exports = {
-    MessageError,
-    TimeoutError,
-    UnroutableMessageError,
-    UndeliverableMessageError,
-    isFatal: require('./client').isFatalError
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,33 +212,14 @@ function getClientClass(apiClass) {
 }
 
 /**
- * Entry point for users. able to start the connection with.
+ * Apply plugins to factories of core method/classes.
  *
- * @typedef {(url?: string | object, options?: Options) => Client} ClientConstructor
- * @typedef {{
- *   start: (url?: string | object, options?: Options) => Promise<Client>,
- *   close: () => void
- * }} Client
- *
- * @type {ClientConstructor & Pick<Client, 'start'>}
- */
-const Client = module.exports = function(url, options = {}) {
-
-    // parse user options
-    const {
-        logger = console,
-        plugins = [],
-        ...opts
-    } = options;
-
-    // context to be passed to plugins. should be smallest
-    const context = {
-        logger
-    };
-
-    // factories of core method/classes. decorated by plugins
-    /** @type {Factories} */
-    const factories = {
+ * @param {{ logger: Logger }} context
+ * @param {Plugin[]} plugins
+ * @return {Factories}
+ * */
+const installPlugins = (context, plugins) => {
+    return {
         [Scopes.CONNECTION]: () => stack(
             context, connect.bind(context), Scopes.CONNECTION, plugins),
         [Scopes.CHANNEL]: (conn) => stack(
@@ -250,6 +231,22 @@ const Client = module.exports = function(url, options = {}) {
         [Scopes.API]: () => stack(
             context, ContextChannel, Scopes.API, plugins)
     };
+};
+
+/**
+ * Entry point for users. able to start the connection with.
+ *
+ * @typedef {(url?: string | object, options?: Options) => Client} ClientConstructor
+ * @typedef {{
+ *   start: (url?: string | object, options?: Options) => Promise<Client>,
+ *   close: () => void
+ * }} Client
+ *
+ * @type {ClientConstructor & Pick<Client, 'start'>}
+ */
+const Client = function(url, { logger = console, plugins = [], ...opts } = {}) {
+
+    const factories = installPlugins({ logger }, plugins);
 
     // observable to be fired when aborting all operations and tearing down
     const { subscribe: aborted, broadcast: abort } = createSubject();
@@ -282,3 +279,9 @@ const Client = module.exports = function(url, options = {}) {
  * @memberof ClientConstructor
  */
 Client.start = (url, options) => Client(url, options).start();
+
+//
+// Exports
+//
+
+module.exports = Client;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,14 +9,69 @@ const { tap } = require('./utils');
 
 
 //
+// Types
+//
+
+/**
+ * @typedef { import("./client").Connection } Connection
+ * @typedef { import("./client").Channel & import("./client").ConfirmChannel } Channel
+ * @typedef { import("./api").Context } Context
+ * @typedef { import("./api").ChannelProperties } ChannelProperties
+ * @typedef { import("./types").Logger } Logger
+ */
+
+/**
+ * @typedef {{ plugins?: Plugin[], logger?: Logger, [key: string]: any }} Options
+ * @typedef {{ new(...args: ContextConstructorParameters): ContextChannel }} ApiConstructor
+ */
+
+/**
+ * Workaround for JSDoc enums not being compiled as TS enums.
+ *
+ * @typedef {{
+ *   ['connection']: () => (...args: import("./client").ConnectParams) => Promise<Connection>,
+ *   ['channel']: (conn: Connection) => (...args: import("./client").CreateChannelParams) => Promise<Channel>,
+ *   ['publication']: (ch: Channel) => (...args: import("./client").PublishParams) => ReturnType<Channel['publish']>,
+ *   ['subscription']: (ch: Channel) => (...args: import("./client").SubscribeParams) => ReturnType<Channel['consume']>,
+ *   ['api']: () => ApiConstructor
+ * }} Factories
+ */
+
+/**
+ * @typedef {any} Plugin
+ */
+
+/**
+ * @typedef {Omit<ChannelProperties, '_self'> & {
+ *   factories: Factories,
+ *   ready: (ch: Channel) => void,
+ *   aborted: Promise<Error>,
+ *   _onClose: () => void,
+ *   _connOpts: {
+ *     url?: string | object,
+ *     options?: Options
+ *   }
+ * }} ClientProperties
+ *
+ * @typedef {[Context | null, ChannelProperties]} ContextConstructorParameters
+ */
+
+
+//
 // Utilities
 //
 
 const noop = () => {};
 
-// create an observable subject.
+/**
+ * Create an observable subject.
+ *
+ * @template T
+ * @return {{ subscribe: Promise<T>, broadcast: (topic: T) => void }}
+ */
 const createSubject = () => {
-    let broadcast, subscribe = new Promise((resolve) => broadcast = resolve);
+    let broadcast = () => {},
+        subscribe = new Promise((resolve) => broadcast = resolve);
     return { broadcast, subscribe };
 };
 
@@ -26,8 +81,13 @@ const createExtendable = () => {
 
     let asserted = subscribe;
 
-    // extend the promise chain by assertions
-    // that are made before publishing
+    /**
+     * Extend the promise chain by assertions
+     * that are made before publishing.
+     *
+     * @template T
+     * @param {(tail: Promise<T>) => Promise<any>} fn
+     */
     const extend = (fn) => {
         const assert = fn(asserted);
         asserted = assert.then(() => subscribe);
@@ -38,21 +98,19 @@ const createExtendable = () => {
 };
 
 /**
- * Create a factory funtion by wrapping the original with the plugins enabled
+ * Create a factory funtion by wrapping the original with the plugins enabled.
  *
- * @this {object}
+ * @template T
+ * @param {object} context
+ * @param {T} original
+ * @param {Scopes} scope
+ * @param {Plugin[]} plugins
+ * @return {T}
  */
-function stack(original, scope, plugins = []) {
+function stack(context, original, scope, plugins = []) {
     return plugins
         .filter((plugin) => plugin.scopes.includes(scope))
-        .reduce((next, plugin) => plugin.wrap(scope, this)(next), original);
-}
-
-// define read-only properties on an object
-function defineProperties(obj, properties) {
-    Object.entries(properties)
-        .forEach(([key, value]) => Object.defineProperty(obj, key, { value }));
-    return obj;
+        .reduce((next, plugin) => plugin.wrap(scope, context)(next), original);
 }
 
 
@@ -60,11 +118,22 @@ function defineProperties(obj, properties) {
 // Client endpoint
 //
 
+/**
+ * @param {ApiConstructor} apiClass
+ */
 function getClientClass(apiClass) {
 
-    // internal class
+    /**
+     * Internal class.
+     *
+     * @class
+     */
     class Client extends apiClass {
 
+        /**
+         * @constructor
+         * @param {ClientProperties} properties
+         */
         constructor({
             factories,
             ready,
@@ -84,24 +153,22 @@ function getClientClass(apiClass) {
                 _self: apiClass
             });
 
-            defineProperties(this, {
-                _connOpts,
-                ready,
-                aborted,
-                factories,
-                _onClose
-            });
+            /** @readonly */
+            this._connOpts = _connOpts;
+            /** @readonly */
+            this.ready = ready;
+            /** @readonly */
+            this.aborted = aborted;
+            /** @readonly */
+            this.factories = factories;
+            /** @readonly */
+            this._onClose = _onClose;
         }
-
-        // static start(url, options = {}) {
-        //     // immediately start the connection
-        //     return new Client(url, options).start();
-        // }
 
         start() {
             const ready = this.ready, abort = this.abort;
 
-            const { url, options } = this._connOpts;
+            const { url = '', options } = this._connOpts;
             this.connect = this.factories.connection();
 
             // initiate connection to the broker
@@ -112,8 +179,9 @@ function getClientClass(apiClass) {
                     return conn;
                 });
 
-            this.createChannel = () => this.conn
-                .then((conn) => this.factories.channel(conn)());
+            this.createChannel = () =>
+                /** @type {Promise<Connection>} */ (this.conn)
+                    .then((conn) => this.factories.channel(conn)());
 
             // open channel(s) using the created connection
             this.ch = this.createChannel()
@@ -130,7 +198,7 @@ function getClientClass(apiClass) {
         }
 
         close() {
-            return this.conn
+            return this.conn && this.conn
                 .then((conn) => conn.close())
                 .catch((err) => {
                     this.logger.warn('[AMQP] An error occurred when closing a connection', err.message);
@@ -146,10 +214,15 @@ function getClientClass(apiClass) {
 /**
  * Entry point for users. able to start the connection with.
  *
- * @typedef {(url?: string | object, options?: object) => any} ClientConstructor
- * @type {ClientConstructor & { start: (url?: string | object, options?: object) => Promise<any> }}
+ * @typedef {(url?: string | object, options?: Options) => Client} ClientConstructor
+ * @typedef {{
+ *   start: (url?: string | object, options?: Options) => Promise<Client>,
+ *   close: () => void
+ * }} Client
+ *
+ * @type {ClientConstructor & Pick<Client, 'start'>}
  */
-const Client = function(url, options = {}) {
+const Client = module.exports = function(url, options = {}) {
 
     // parse user options
     const {
@@ -164,16 +237,17 @@ const Client = function(url, options = {}) {
     };
 
     // factories of core method/classes. decorated by plugins
+    /** @type {Factories} */
     const factories = {
-        connection: () => stack.call(
+        [Scopes.CONNECTION]: () => stack(
             context, connect.bind(context), Scopes.CONNECTION, plugins),
-        channel: (conn) => stack.call(
+        [Scopes.CHANNEL]: (conn) => stack(
             context, conn.createConfirmChannel.bind(conn), Scopes.CHANNEL, plugins),
-        publication: (ch) => stack.call(
+        [Scopes.PUBLICATION]: (ch) => stack(
             context, ch.publish.bind(ch), Scopes.PUBLICATION, plugins),
-        subscription: (ch) => stack.call(
+        [Scopes.SUBSCRIPTION]: (ch) => stack(
             context, ch.consume.bind(ch), Scopes.SUBSCRIPTION, plugins),
-        api: () => stack.call(
+        [Scopes.API]: () => stack(
             context, ContextChannel, Scopes.API, plugins)
     };
 
@@ -208,13 +282,3 @@ const Client = function(url, options = {}) {
  * @memberof ClientConstructor
  */
 Client.start = (url, options) => Client(url, options).start();
-
-
-//
-// Exports
-//
-
-/**
- * @type ClientConstructor
- */
-module.exports = Client;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,11 +13,11 @@ const { tap } = require('./utils');
 //
 
 /**
- * @typedef { import("./client").Connection } Connection
- * @typedef { import("./client").Channel & import("./client").ConfirmChannel } Channel
- * @typedef { import("./api").Context } Context
- * @typedef { import("./api").ChannelProperties } ChannelProperties
- * @typedef { import("./types").Logger } Logger
+ * @typedef {import('./client').Connection} Connection
+ * @typedef {import('./client').Channel & import('./client').ConfirmChannel} Channel
+ * @typedef {import('./api').Context} Context
+ * @typedef {import('./api').ChannelProperties} ChannelProperties
+ * @typedef {import('./types').Logger} Logger
  */
 
 /**
@@ -29,10 +29,10 @@ const { tap } = require('./utils');
  * Workaround for JSDoc enums not being compiled as TS enums.
  *
  * @typedef {{
- *   ['connection']: () => (...args: import("./client").ConnectParams) => Promise<Connection>,
- *   ['channel']: (conn: Connection) => (...args: import("./client").CreateChannelParams) => Promise<Channel>,
- *   ['publication']: (ch: Channel) => (...args: import("./client").PublishParams) => ReturnType<Channel['publish']>,
- *   ['subscription']: (ch: Channel) => (...args: import("./client").SubscribeParams) => ReturnType<Channel['consume']>,
+ *   ['connection']: () => (...args: import('./client').ConnectParams) => Promise<Connection>,
+ *   ['channel']: (conn: Connection) => (...args: import('./client').CreateChannelParams) => Promise<Channel>,
+ *   ['publication']: (ch: Channel) => (...args: import('./client').PublishParams) => ReturnType<Channel['publish']>,
+ *   ['subscription']: (ch: Channel) => (...args: import('./client').SubscribeParams) => ReturnType<Channel['consume']>,
  *   ['api']: () => ApiConstructor
  * }} Factories
  */

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,11 @@ const createExtendable = () => {
     return { extend, subscribe: () => asserted, broadcast };
 };
 
-// create a factory funtion by wrapping the original with the plugins enabled
+/**
+ * Create a factory funtion by wrapping the original with the plugins enabled
+ *
+ * @this {object}
+ */
 function stack(original, scope, plugins = []) {
     return plugins
         .filter((plugin) => plugin.scopes.includes(scope))
@@ -89,10 +93,10 @@ function getClientClass(apiClass) {
             });
         }
 
-        static start(url, options = {}) {
-            // immediately start the connection
-            return new Client(url, options).start();
-        }
+        // static start(url, options = {}) {
+        //     // immediately start the connection
+        //     return new Client(url, options).start();
+        // }
 
         start() {
             const ready = this.ready, abort = this.abort;
@@ -139,7 +143,12 @@ function getClientClass(apiClass) {
 
 }
 
-// the entry point for users. able to start the connection with
+/**
+ * Entry point for users. able to start the connection with.
+ *
+ * @typedef {(url?: string | object, options?: object) => any} ClientConstructor
+ * @type {ClientConstructor & { start: (url?: string | object, options?: object) => Promise<any> }}
+ */
 const Client = function(url, options = {}) {
 
     // parse user options
@@ -195,10 +204,17 @@ const Client = function(url, options = {}) {
 
 };
 
+/**
+ * @memberof ClientConstructor
+ */
+Client.start = (url, options) => Client(url, options).start();
+
 
 //
 // Exports
 //
 
+/**
+ * @type ClientConstructor
+ */
 module.exports = Client;
-module.exports.start = (url, options) => new Client(url, options).start();

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,10 @@
+module.exports = {};
+/**
+ * @typedef {(msg: any, ...params: any[]) => void} LogMethod
+ * @typedef {{
+ *   info: LogMethod,
+ *   warn: LogMethod,
+ *   error: LogMethod,
+ *   debug: LogMethod
+ * }} Logger
+ */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 /**
  * @template T
- * @param {function} fn
+ * @param {(arg: T) => any} fn
  * @return {(arg: T) => Promise<T>}
  */
 const tap = (fn) => (arg) => Promise

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,8 @@
+/**
+ * @template T
+ * @param {function} fn
+ * @return {(arg: T) => Promise<T>}
+ */
 const tap = (fn) => (arg) => Promise
     .resolve()
     .then(() => fn(arg))

--- a/package-lock.json
+++ b/package-lock.json
@@ -321,10 +321,32 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@types/amqplib": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.13.tgz",
+      "integrity": "sha512-0r8cJfUajAlcHxlJsZyqRrSAYzv+pJPsaAQjDC6e5rACi3AOIuR0AfevJG7NLvw3Qu4EGhf3KS/ECwd5cUAY2A==",
+      "dev": true,
+      "requires": {
+        "@types/bluebird": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/bluebird": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
+      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==",
+      "dev": true
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.12.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
+      "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg==",
       "dev": true
     },
     "acorn": {
@@ -2712,6 +2734,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
     "puid": "^1.0.7"
   },
   "devDependencies": {
+    "@types/amqplib": "^0.5.13",
+    "@types/node": "< 13",
     "eslint": "^6.8.0",
     "mocha": "^7.1.2",
-    "nyc": "^15.0.1"
+    "nyc": "^15.0.1",
+    "typescript": "^3.9.3"
   }
 }

--- a/plugins/helpers.js
+++ b/plugins/helpers.js
@@ -21,6 +21,11 @@ module.exports = {
         forwardAll: forwardAllEvents
     },
     promise: {
+        /**
+         * @template T
+         * @param {(msg: any) => Promise<T>} fn
+         * @return {Promise<T>}
+         * */
         wrap: (fn) => Promise.resolve().then(fn)
     },
     expose: (src, dst, ...members) => {

--- a/plugins/recover.js
+++ b/plugins/recover.js
@@ -6,7 +6,7 @@ const { TimeoutError } = require('../lib/errors');
 
 class Recoverable extends EventEmitter {
 
-    constructor(conn, create, { logger, timeout = 5 * 1e3 } = {}) {
+    constructor(conn, create, { logger = console, timeout = 5 * 1e3 } = {}) {
         super();
 
         this.logger = logger;

--- a/plugins/retry/errors.js
+++ b/plugins/retry/errors.js
@@ -1,5 +1,9 @@
 const { MessageError } = require('../../lib/errors');
 
+/**
+ * @typedef { import("../../lib/errors").MessageError } MessageError
+ */
+
 class RetryError extends MessageError {
     constructor(err, msg) {
         if (RetryError.promotable(err)) {

--- a/plugins/retry/errors.js
+++ b/plugins/retry/errors.js
@@ -1,7 +1,7 @@
 const { MessageError } = require('../../lib/errors');
 
 /**
- * @typedef { import("../../lib/errors").MessageError } MessageError
+ * @typedef {import('../../lib/errors').MessageError} MessageError
  */
 
 class RetryError extends MessageError {

--- a/plugins/retry/index.js
+++ b/plugins/retry/index.js
@@ -9,6 +9,10 @@ const errors = require('./errors');
 
 const { RetryError } = errors;
 
+/**
+ * @typedef { import("../../lib/api") } ContextChannel
+ */
+
 function assertDelayQueue(delay, exchange) {
     const { name, options } = configs.queue({ delay, exchange });
     const { name: ex } = configs.exchange();
@@ -22,6 +26,7 @@ function assertDelayQueue(delay, exchange) {
     };
 }
 
+/** @this {ContextChannel} */
 function retry(msg, count, delay = 500) {
     const { fields: { exchange, routingKey } } = msg;
     const { name: delayExchange } = configs.exchange();
@@ -70,7 +75,11 @@ module.exports = class extends Plugin {
 
         return class extends constructor {
 
-            consume(queue, fn, { retries, retry: localOptions, ...options } = {}) {
+            consume(queue, fn, {
+                retries = globalOptions.retries,
+                retry: localOptions = {},
+                ...options
+            } = {}) {
                 retries = retries >= 0 ? retries : globalOptions.retries;
 
                 const computeDelay = backoff({ ...globalOptions, ...localOptions });

--- a/plugins/retry/index.js
+++ b/plugins/retry/index.js
@@ -10,7 +10,7 @@ const errors = require('./errors');
 const { RetryError } = errors;
 
 /**
- * @typedef { import("../../lib/api") } ContextChannel
+ * @typedef {import('../../lib/api')} ContextChannel
  */
 
 function assertDelayQueue(delay, exchange) {

--- a/plugins/rpc/api.js
+++ b/plugins/rpc/api.js
@@ -133,4 +133,4 @@ module.exports = function(config) {
                     return super.consume(queue, reply.call(this, fn), options);
                 }
             };
-}
+};

--- a/plugins/rpc/api.js
+++ b/plugins/rpc/api.js
@@ -4,7 +4,7 @@ const { TimeoutError } = require('../../lib/errors');
 const errors = require('./errors');
 
 /**
- * @typedef { import("../../lib/api") } ContextChannel
+ * @typedef {import('../../lib/api')} ContextChannel
  *
  * @typedef {object} RPCMethods
  * @property {EventEmitter} _resp

--- a/plugins/rpc/errors.js
+++ b/plugins/rpc/errors.js
@@ -36,7 +36,7 @@ const serialize = (err) => {
     }
     return {
         content: Buffer.from(JSON.stringify(err.toString())),
-        options: { contentType: 'application/json' }
+        options: { headers: {}, contentType: 'application/json' }
     };
 };
 

--- a/plugins/rpc/index.js
+++ b/plugins/rpc/index.js
@@ -4,18 +4,16 @@ const errors = require('./errors');
 
 const Puid = require('puid');
 
-module.exports = class extends Plugin {
+module.exports = class RPCPlugin extends Plugin {
 
     constructor({ uid = new Puid(), timeout = 0 } = {}) {
         super();
-
-        this.uid = uid, this.timeout = timeout;
 
         this.wrappers = {
 
             [Scopes.CHANNEL]: this.replyOnNack,
 
-            [Scopes.API]: require('./api')(this),
+            [Scopes.API]: require('./api')({ uid, timeout }),
 
         };
     }
@@ -25,7 +23,7 @@ module.exports = class extends Plugin {
             .then((ch) => {
                 const nack = ch.nack;
                 ch.nack = function(msg, multiple, requeue, err) {
-                    nack.apply(ch, arguments);
+                    nack.call(ch, msg, multiple, requeue);
 
                     // not a rpc
                     if (!msg.properties.replyTo) return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "allowJs": true,
+    "checkJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "types",
+    // "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "baseUrl": "./"
+  },
+  "include": [
+      "**/*.js"
+  ],
+  "exclude": [
+      "coverage",
+      "examples",
+      "**/*.spec.js"
+  ]
+}


### PR DESCRIPTION
Related: https://github.com/openrm/hato/issues/16

`make types` generates a directory named `types` that include type definitions (`.d.ts`).
They could actually be bundled in the public package when we have completely typed it :thinking: 