### PR TITLE
Feature/consumer emitter

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,7 +8,7 @@
 const assert = require('assert');
 
 const { EventEmitter } = require('events');
-const Consumer = require('./consumer');
+const consumers = require('./consumer');
 const defaults = require('./defaults');
 const { ExchangeTypes } = require('./constants');
 const { tap } = require('./utils');
@@ -34,7 +34,7 @@ const exchangeTypes = Object.values(ExchangeTypes);
  */
 /**
  * @template T
- * @typedef {import('./consumer').IConsumer<T>} Consumer<T>
+ * @typedef {import('./consumer').Consumer<T>} Consumer<T>
  */
 
 /**
@@ -296,14 +296,12 @@ class ContextChannel extends EventEmitter {
         }
 
         // start consuming in the assertion phase.
-        /** @type {Promise<ConsumeReply>} */
-        const consuming = this._assert((ch) => bind(ch)
-            .then(({ ch, queue }) => this._consume(ch, queue, fn, options, consumer)));
+        /** @param {EventEmitter} emitter */
+        const consume = (emitter) =>
+            this._assert((ch) => bind(ch)
+                .then(({ ch, queue }) => this._consume(ch, queue, fn, options, emitter)))
 
-        const consumer = new Consumer(
-            (resolve, reject) => consuming.then(resolve).catch(reject));
-
-        return consumer;
+        return consumers.create(consume);
     }
 
     /**

--- a/lib/api.js
+++ b/lib/api.js
@@ -299,7 +299,7 @@ class ContextChannel extends EventEmitter {
         /** @param {EventEmitter} emitter */
         const consume = (emitter) =>
             this._assert((ch) => bind(ch)
-                .then(({ ch, queue }) => this._consume(ch, queue, fn, options, emitter)))
+                .then(({ ch, queue }) => this._consume(ch, queue, fn, options, emitter)));
 
         return consumers.create(consume);
     }

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,6 +8,7 @@
 const assert = require('assert');
 
 const { EventEmitter } = require('events');
+const Consumer = require('./consumer');
 const defaults = require('./defaults');
 const { ExchangeTypes } = require('./constants');
 const { tap } = require('./utils');
@@ -29,11 +30,15 @@ const exchangeTypes = Object.values(ExchangeTypes);
  * @typedef {import('amqplib').Message} Message
  * @typedef {import('amqplib').ConsumeMessage} ConsumeMessage
  * @typedef {import('amqplib').Replies.Empty} EmptyReply
+ * @typedef {import('amqplib').Replies.Consume} ConsumeReply
+ */
+/**
+ * @template T
+ * @typedef {import('./consumer').IConsumer<T>} Consumer<T>
  */
 
 /**
  * @typedef {{ exchange: string, queue: string, assert: boolean }} Context
- * @typedef {{ consumerTag: string, consumer: EventEmitter }} Consumer
  */
 
 /**
@@ -236,7 +241,7 @@ class ContextChannel extends EventEmitter {
      * @param {string | object} binding
      * @param {Handler} fn
      * @param {object} [options]
-     * @return {Promise<Consumer>}
+     * @return {Consumer<ConsumeReply>}
      */
     subscribe(binding, fn, options) {
         return this.consume.call(this, binding, fn, options);
@@ -248,7 +253,7 @@ class ContextChannel extends EventEmitter {
      * @param {string | object} binding
      * @param {Handler} fn
      * @param {object} [options]
-     * @return {Promise<Consumer>}
+     * @return {Consumer<ConsumeReply>}
      */
     consume(binding, fn, options) {
         // allow to omit the binding key for use with fanout exchanges
@@ -290,9 +295,15 @@ class ContextChannel extends EventEmitter {
                 });
         }
 
-        // start consuming in the assertion phase
-        return this._assert((ch) => bind(ch)
-            .then(({ ch, queue }) => this._consume(ch, queue, fn, options)));
+        // start consuming in the assertion phase.
+        /** @type {Promise<ConsumeReply>} */
+        const consuming = this._assert((ch) => bind(ch)
+            .then(({ ch, queue }) => this._consume(ch, queue, fn, options, consumer)));
+
+        const consumer = new Consumer(
+            (resolve, reject) => consuming.then(resolve).catch(reject));
+
+        return consumer;
     }
 
     /**
@@ -300,11 +311,10 @@ class ContextChannel extends EventEmitter {
      * @param {string} queue
      * @param {Handler} fn
      * @param {object} [options]
-     * @return Promise<Consumer>
+     * @param {EventEmitter} [emitter]
+     * @return {Promise<ConsumeReply>}
      */
-    _consume(ch, queue, fn, options) {
-        // provides a way to debug errors
-        const emitter = new EventEmitter();
+    _consume(ch, queue, fn, options, emitter = new EventEmitter()) {
         /** @type {string} */
         let tag;
         /** @type {Handler} */
@@ -327,9 +337,7 @@ class ContextChannel extends EventEmitter {
                 });
         };
         return ch.consume(queue, handler, options)
-            .then(tap(({ consumerTag }) => tag = consumerTag))
-            .then((consumer) =>
-                Object.assign(consumer, { consumer: emitter }));
+            .then(tap(({ consumerTag }) => tag = consumerTag));
     }
 
     /**

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -27,7 +27,7 @@ const applyMixin = function(ctor, baseCtor, instance) {
             ctor.prototype[name] = instance[name];
         });
     return ctor;
-}
+};
 
 /**
  * Create a promise with a bound event emitter.
@@ -37,7 +37,7 @@ const applyMixin = function(ctor, baseCtor, instance) {
  * @return {Consumer<T>}
  */
 module.exports.create = function(fn) {
-    const Consumer = class extends Promise {}
+    const Consumer = class extends Promise {};
     const emitter = new EventEmitter();
     /** @type {{ new<T>(exec: Executor<T>): Consumer<T> }} */
     const clazz = applyMixin(Consumer, EventEmitter, emitter);

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -2,7 +2,7 @@ const { EventEmitter } = require('events');
 
 /**
  * @template T
- * @typedef {Promise<T> & EventEmitter} IConsumer
+ * @typedef {Promise<T> & EventEmitter} Consumer
  */
 
 /**
@@ -11,25 +11,35 @@ const { EventEmitter } = require('events');
  */
 
 /**
- * @type {Omit<typeof Promise, 'prototype'> & {
- *   new<T>(executor: Executor<T>): IConsumer<T>
- * }} ConsumerConstructor
- * @template T
- * @param {Executor<T>} executor
+ * Apply a mixin, but using an instance as source.
+ *
+ * @template {function & { new(...args: any): any }} T
+ * @template {function & { new(...args: any): any }} U
+ * @param {T} ctor
+ * @param {U} baseCtor
+ * @param {InstanceType<U>} instance
+ * @return {{ new(...args: any): InstanceType<T> & InstanceType<U> }}
  */
-const Consumer = module.exports = function Consumer(executor) {
-    /** @type {{ [name: string]: any }} */
-    const emitter = new EventEmitter();
-    const clazz = function() {};
-    clazz.prototype = Object.create(Consumer.prototype);
-    Object.getOwnPropertyNames(EventEmitter.prototype)
+const applyMixin = function(ctor, baseCtor, instance) {
+    Object.getOwnPropertyNames(baseCtor.prototype)
         .filter((name) => name !== 'constructor')
         .forEach((name) => {
-            clazz.prototype[name] = emitter[name];
+            ctor.prototype[name] = instance[name];
         });
-    return Reflect.construct(Promise, [executor], clazz);
-};
+    return ctor;
+}
 
-Object.setPrototypeOf(Consumer, Promise);
-Consumer.prototype = Object.create(Promise.prototype);
-Consumer.prototype.constructor = Consumer;
+/**
+ * Create a promise with a bound event emitter.
+ *
+ * @template T
+ * @param {(consumer: EventEmitter) => Promise<T>} fn
+ * @return {Consumer<T>}
+ */
+module.exports.create = function(fn) {
+    const Consumer = class extends Promise {}
+    const emitter = new EventEmitter();
+    /** @type {{ new<T>(exec: Executor<T>): Consumer<T> }} */
+    const clazz = applyMixin(Consumer, EventEmitter, emitter);
+    return new clazz((resolve, reject) => fn(emitter).then(resolve, reject));
+};

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -1,0 +1,35 @@
+const { EventEmitter } = require('events');
+
+/**
+ * @template T
+ * @typedef {Promise<T> & EventEmitter} IConsumer
+ */
+
+/**
+ * @template T
+ * @typedef {(resolve: (result: T) => void, reject: (reason: any) => void) => void} Executor
+ */
+
+/**
+ * @type {Omit<typeof Promise, 'prototype'> & {
+ *   new<T>(executor: Executor<T>): IConsumer<T>
+ * }} ConsumerConstructor
+ * @template T
+ * @param {Executor<T>} executor
+ */
+const Consumer = module.exports = function Consumer(executor) {
+    /** @type {{ [name: string]: any }} */
+    const emitter = new EventEmitter();
+    const clazz = function() {};
+    clazz.prototype = Object.create(Consumer.prototype);
+    Object.getOwnPropertyNames(EventEmitter.prototype)
+        .filter((name) => name !== 'constructor')
+        .forEach((name) => {
+            clazz.prototype[name] = emitter[name];
+        });
+    return Reflect.construct(Promise, [executor], clazz);
+};
+
+Object.setPrototypeOf(Consumer, Promise);
+Consumer.prototype = Object.create(Promise.prototype);
+Consumer.prototype.constructor = Consumer;

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,8 +84,7 @@ const createExtendable = () => {
      * Extend the promise chain by assertions
      * that are made before publishing.
      *
-     * @template T
-     * @param {(tail: Promise<T>) => Promise<any>} fn
+     * @type {<T, U>(fn: (tail: Promise<T>) => Promise<U>) => Promise<U>}
      */
     const extend = (fn) => {
         const assert = fn(asserted);

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -9,10 +9,16 @@ describe('client', () => {
         const thing = 'thing';
         const consumer = client
             .subscribe('some.key', () => { throw thing; })
+            .then(({ consumerTag }) => {
+                assert(consumerTag);
+                return 'resolved';
+            })
             .on('error', (err) => {
                 assert.strictEqual(err, thing);
                 client.close().then(() => done());
-            });
+            })
+            .then((text) => assert.strictEqual(text, 'resolved'))
+            .catch(done);
 
         assert(consumer instanceof Promise);
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -1,14 +1,44 @@
 const assert = require('assert');
+const { EventEmitter } = require('events');
 const { Client } = require('..');
 
 describe('client', () => {
+    it('should emit an unhandled consumer error', (done) => {
+        const client = new Client();
+
+        const thing = 'thing';
+        const consumer = client
+            .subscribe('some.key', () => { throw thing; })
+            .on('error', (err) => {
+                assert.strictEqual(err, thing);
+                client.close().then(() => done());
+            });
+
+        assert(consumer instanceof Promise);
+
+        // check for pseudo inheritance
+        const proto = EventEmitter.prototype;
+        Object.getOwnPropertyNames(proto)
+            .forEach((name) => {
+                if (name === 'constructor') return;
+                if (typeof proto[name] === 'function') {
+                    assert.strictEqual(consumer[name], proto[name]);
+                }
+            });
+
+        client
+            .start()
+            .then(() => client.publish('some.key', Buffer.from('hello')))
+            .catch(done);
+    });
+
     it('should exit on connection failure', (done) => {
         const client = new Client('amqp://invalid.host');
         client.start()
             .then(() => done(new Error('Connection must fail')))
             .catch((err) => {
                 assert.strictEqual(err.cause.code, 'ENOTFOUND');
-                done();
+                client.close().then(() => done());
             });
     });
 


### PR DESCRIPTION
This is a proposal, it doesn't necessarily improve the user experience greatly :thinking: 
(Still, it simplifies the assertions in the test suites, let me show this later)

The new class (that extends `Promise`) allows users to directly listen on the promise returned by `consume()`, for example:
```js
client
    .consume('a.key', (msg) => {
        ...
        throw new Error('unhandled');
    })
    .on('error', (err) => {}) // the returned value implements EventEmitter
    .then(({ consumerTag }) => consumers.push(consumerTag)); // the returned value is still a promise
```