### PR TITLE
Fix event forwarding

### DIFF
--- a/plugins/helpers.js
+++ b/plugins/helpers.js
@@ -10,7 +10,7 @@ const breakLoop = function(name, fn) {
             fn(...args);
         }
     };
-}
+};
 
 const hook = asyncHooks.createHook({
     init: (aid, type, tid) => {

--- a/plugins/helpers.js
+++ b/plugins/helpers.js
@@ -1,5 +1,12 @@
+const state = new WeakMap();
+
 function forwardEvents(src, dst, ...events) {
-    events.forEach((name) => src.on(name, dst.emit.bind(dst)));
+    events.forEach((name) => src.on(name, (...args) => {
+        if (state.has(dst) && state.get(dst).includes(name)) return;
+        state.set(src, (state.get(src) || []).concat(name));
+        dst.emit(name, ...args);
+        state.set(src, state.get(src).filter(_name => _name !== name));
+    }));
     return dst;
 }
 

--- a/plugins/helpers.js
+++ b/plugins/helpers.js
@@ -13,7 +13,7 @@ const breakLoop = function(name, fn) {
 };
 
 const hook = asyncHooks.createHook({
-    init: (aid, type, tid) => {
+    init: (aid, _, tid) => {
         if (state.has(tid)) state.set(aid, state.get(tid));
     },
     destroy: (aid) => state.delete(aid)


### PR DESCRIPTION
Fixes three bugs with event forwarding:
- the wrapper class in `duplex` plugin was breaking event propagation
- the helper function to patch events through two emitters had an invalid code inside
- there was a potential infinite loop regarding this

The helper is actually fundamental to our plugin system, as wrapper classes must not block any event either from the underlying event emitter, or from the end-users