### PR TITLE
Reorganize error handling in rpc/retry plugins

### DIFF
--- a/lib/ack.js
+++ b/lib/ack.js
@@ -1,0 +1,35 @@
+const key = Symbol.for('hato.ack.state');
+
+/**
+ * @param {import('./api').Channel} ch
+ * @param {import('./api').Message} msg
+ */
+module.exports.createState = (ch, msg) => {
+    let acked = false;
+    /** @type {boolean[]} */
+    const state = [];
+    /**
+     * @param {(...args: boolean[]) => void} fn
+     * @param {boolean} negative
+     */
+    const once = (fn, negative) => ({
+        writable: true,
+        /**
+         * @type {(...args: boolean[]) => void}
+         */
+        value: (...args) => {
+            if (acked) return;
+            acked = true;
+            fn(...args);
+            state.push(negative, ...args);
+        }
+    });
+    return {
+        ack: once(ch.ack.bind(ch, msg), false),
+        nack: once(ch.nack.bind(ch, msg), true),
+        // nack() does not work on RabbitMQ < v2.3.0,
+        // use reject() instead
+        reject: once(ch.reject.bind(ch, msg), true),
+        [key]: { get: () => state }
+    };
+};

--- a/lib/api.js
+++ b/lib/api.js
@@ -10,6 +10,7 @@ const assert = require('assert');
 const { EventEmitter } = require('events');
 const consumers = require('./consumer');
 const defaults = require('./defaults');
+const ack = require('./ack');
 const { ExchangeTypes } = require('./constants');
 const { tap } = require('./utils');
 
@@ -316,15 +317,10 @@ class ContextChannel extends EventEmitter {
         /** @type {Handler} */
         const handler = (msg) => {
             if (!msg) return fn(msg);
+            Object.defineProperties(msg, ack.createState(ch, msg));
             // wrap (possibly sync.) handler in a promise.
             return Promise.resolve()
-                .then(() => fn(Object.assign(msg, {
-                    ack: ch.ack.bind(ch, msg),
-                    nack: ch.nack.bind(ch, msg),
-                    // nack() does not work on RabbitMQ < v2.3.0,
-                    // use reject() instead
-                    reject: ch.reject.bind(ch, msg)
-                })))
+                .then(() => fn(msg))
                 .catch((err) => emitter.emit('error', err, msg))
                 .catch((err) => {
                     this.logger.error(

--- a/plugins/retry/errors.js
+++ b/plugins/retry/errors.js
@@ -29,7 +29,9 @@ class RetryError extends MessageError {
 }
 
 function isRetryable(err) {
-    if (RetryError.promotable(err)) return false;
+    if (err instanceof RetryError ||
+        RetryError.promotable(err) ||
+        err.cause && err.cause.message.startsWith('Channel ended')) return false;
     else if (err instanceof MessageError) {
         const { properties: { headers } } = err.msg;
         return headers['x-retry-error'] !== true;

--- a/plugins/rpc/api.js
+++ b/plugins/rpc/api.js
@@ -29,26 +29,11 @@ function rpc(routingKey, msg, { uid, timeout, ...options }) {
             new Promise(rpc({ replyTo, correlationId, timeout, ...options })));
 }
 
-function ackOnce(msg) {
-    let acked = false;
-    const once = (fn) => (...args) => {
-        if (acked) return;
-        else acked = true;
-        return fn(...args);
-    };
-    msg.ack = once(msg.ack.bind(msg));
-    msg.nack = once(msg.nack.bind(msg));
-    msg.reject = once(msg.reject.bind(msg));
-    return msg;
-}
-
 /**
  * @this {RPCChannel}
- * @param {(msg: any) => Promise<any>} fn
- * @return {(msg: any) => Promise<any>} fn
  */
-function reply(fn) {
-    return (msg) => {
+function serveRpc(consume, queue, fn, options) {
+    const handler = (msg) => {
         const {
             replyTo,
             correlationId
@@ -57,20 +42,51 @@ function reply(fn) {
         // not a rpc
         if (!replyTo) return fn(msg);
 
-        msg = ackOnce(msg);
+        let replied = false;
+
+        const reply = (err, res) => {
+            if (replied) return;
+            else replied = true;
+
+            let respond;
+
+            if (err) {
+                const { content, options } = errors.serialize(err);
+                const headers = { ...msg.properties.headers, ...options.headers };
+                respond = (ch) => ch
+                    .publish('', replyTo, content, { ...options, headers, correlationId });
+            } else {
+                respond = (ch) => ch
+                    .publish('', replyTo, res, { correlationId });
+            }
+
+            return this._asserted()
+                .then(respond)
+                .then(() => msg.ack())
+                .catch((err) => {
+                    this.logger.error(
+                        '[AMQP:rpc] Failed to reply back to client.',
+                        err);
+                });
+        };
+
+        msg.reply = reply;
 
         return promise
             .wrap(() => fn(msg))
-            .then((res) => this._asserted()
-                .then((ch) =>
-                    ch.publish('', replyTo, res, { correlationId }))
-                .then(() => msg.ack()));
+            .then((res) => reply(null, res));
     };
+
+    return consume
+        .call(this, queue, handler, options)
+        .on('error', (err, msg) =>
+            typeof msg.reply === 'function' && msg.reply(err));
 }
 
 /** @this {RPCChannel} */
 function makeRpc(routingKey, msg, { timeout, ...options }) {
     const { correlationId, replyTo } = options;
+
     return (resolve, reject) => {
         const fn = (msg) =>
             this._resp.emit(msg.properties.correlationId, msg);
@@ -130,7 +146,7 @@ module.exports = function(config) {
             }
 
             consume(queue, fn, options) {
-                return super.consume(queue, reply.call(this, fn), options);
+                return serveRpc.call(this, super.consume, queue, fn, options);
             }
         };
 };

--- a/plugins/rpc/errors.js
+++ b/plugins/rpc/errors.js
@@ -32,8 +32,10 @@ const serialize = (err) => {
             }
         };
     }
+    let content = err.toString();
+    if (err instanceof Error) content = err.message;
     return {
-        content: Buffer.from(JSON.stringify(err.toString())),
+        content: Buffer.from(JSON.stringify(content)),
         options: {
             headers: {
                 [Keys.error]: true

--- a/plugins/rpc/index.js
+++ b/plugins/rpc/index.js
@@ -1,6 +1,5 @@
 const Plugin = require('../base');
 const { Scopes } = require('../../lib/constants');
-const errors = require('./errors');
 
 const Puid = require('puid');
 
@@ -13,37 +12,7 @@ module.exports = class RPCPlugin extends Plugin {
     }
 
     init() {
-        this.scopes[Scopes.CHANNEL] = this.replyOnNack;
-
         this.scopes[Scopes.API] = require('./api')(this.options);
-    }
-
-    replyOnNack(create) {
-        return () => create()
-            .then((ch) => {
-                const nack = ch.nack;
-                ch.nack = function(msg, multiple, requeue, err) {
-                    nack.call(ch, msg, multiple, requeue);
-
-                    // not a rpc
-                    if (!msg.properties.replyTo) return;
-                    if (requeue || !err) return;
-
-                    const { replyTo, correlationId } = msg.properties;
-
-                    try {
-                        const { content, options } = errors.serialize(err);
-                        const headers = { ...msg.properties.headers, ...options.headers };
-                        ch.publish(
-                            '', replyTo, content, { ...options, headers, correlationId });
-                    } catch (err) {
-                        this.logger.error(
-                            '[AMQP:rpc] Failed to report the error back to client.',
-                            err);
-                    }
-                };
-                return ch;
-            });
     }
 
 };


### PR DESCRIPTION
### Background

As plugins needed to *ensure* acknowledgements of certain messages (e.g. ack'ing after a retry message is dispatched) there had to be some mechanisms to centralize the state of acknowledgement to also accept them from users.
In addition, there is a case where a plugin handler acting depending on the user acknowledgements (e.g. the retry plugin should not do so when the message is negatively acknowledged)

This finally led to the ack state object who ensures ack's of only one time, and also remembers the first (effective) acknowledgement.