### PR TITLE
Provide an easier way to cancel consumers

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -333,7 +333,11 @@ class ContextChannel extends EventEmitter {
                 });
         };
         return ch.consume(queue, handler, options)
-            .then(tap(({ consumerTag }) => tag = consumerTag));
+            .then(tap(({ consumerTag }) => tag = consumerTag))
+            .then((consumer) => Object.defineProperty(
+                consumer, 'cancel', {
+                    value: () => ch.cancel(consumer.consumerTag)
+                }));
     }
 
     /**

--- a/lib/api.spec.js
+++ b/lib/api.spec.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const { Client } = require('..');
 
 describe('api', () => {
@@ -27,5 +28,24 @@ describe('api', () => {
                 .type('direct')
                 .publish('a.routing.key', Buffer.from('1')))
             .catch(done);
+    });
+
+    it('should provide a property on consumer to cancel itself', async function() {
+        await client.start();
+        const consumer = await client
+            .subscribe('a.key', () => {});
+
+        assert.ok(consumer.cancel);
+        assert.strictEqual(typeof consumer.cancel, 'function');
+
+        const ch = await client._asserted();
+
+        sinon.spy(ch);
+        consumer.cancel();
+
+        assert.ok(ch.cancel.calledOnce);
+        assert.strictEqual(ch.cancel.args[0][0], consumer.consumerTag);
+
+        sinon.restore();
     });
 });


### PR DESCRIPTION
I thought a consumer can have a bound function to cancel itself, just like a message object has its own for acknowledgements