### PR TITLE
Ensure one-time shutdown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -199,18 +199,19 @@ function getClientClass(apiClass) {
         }
 
         close() {
-            return this.ch && this.ch
+            if (this._closing) return this._closing;
+            return this._closing = this.ch && this.ch
                 .then((ch) => ch && ch.close())
                 .catch((err) => {
                     this.logger.warn(
-                        '[AMQP] An error occurred when closing the channel',
+                        '[AMQP] An error occurred when closing the channel:',
                         err.message);
                 })
                 .then(() => this.conn)
                 .then((conn) => conn && conn.close())
                 .catch((err) => {
                     this.logger.warn(
-                        '[AMQP] An error occurred when closing the connection',
+                        '[AMQP] An error occurred when closing the connection:',
                         err.message);
                 });
         }


### PR DESCRIPTION
Hopefully the last issue with closing. It returns a single promise to shutdown the connection for repeated calls.