### PR TITLE
Expose method to set per-consumer prefetch count

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -39,7 +39,12 @@ const exchangeTypes = Object.values(ExchangeTypes);
  */
 
 /**
- * @typedef {{ exchange: string, queue: string, assert: boolean }} Context
+ * @typedef {{
+ *   exchange: string,
+ *   queue: string,
+ *   assert: boolean,
+ *   prefetch: number
+ * }} Context
  */
 
 /**
@@ -87,6 +92,7 @@ class ContextChannel extends EventEmitter {
             queue: '',
             exchange: '',
             assert: true,
+            prefetch: 0,
             ...context
         };
 
@@ -112,6 +118,17 @@ class ContextChannel extends EventEmitter {
      */
     assert(assert = true) {
         return this.context({ assert });
+    }
+
+    /**
+     * Set the prefetch count that is applied to any consumption
+     * under the context.
+     *
+     * @param {number} count
+     * @return {ContextChannel}
+     */
+    prefetch(count) {
+        return this.context({ prefetch: count });
     }
 
     /**
@@ -264,9 +281,13 @@ class ContextChannel extends EventEmitter {
         assert(typeof binding === 'string' || binding &&
             typeof binding === 'object', 'Binding key or object not valid');
 
-        const { queue, exchange, assert: assertion } = this._validateContext();
+        const { queue, exchange, assert: assertion, prefetch } = this._validateContext();
 
-        /** @type {(ch: Promise<Channel>) => Promise<{ ch: Channel, queue: string }>} */
+        const qos = prefetch > 0 ?
+            (ch) => ch.prefetch(prefetch).then(() => ch) :
+            (ch) => Promise.resolve(ch);
+
+        /** @type {(ch: Channel) => Promise<{ ch: Channel, queue: string }>} */
         let bind;
         const opts = defaults.options.anonymousQueue;
 
@@ -274,31 +295,32 @@ class ContextChannel extends EventEmitter {
             assert(typeof binding === 'string');
             // using the default exchange
             // (messages are sent to a queue with name same as the binding key)
-            bind = (ch) => ch
-                .then((ch) => ch.assertQueue(binding, opts)
-                    .then(({ queue }) => ({ queue, ch })));
+            bind = (ch) => ch.assertQueue(binding, opts)
+                .then(({ queue }) => ({ queue, ch }));
         } else {
             // otherwise explicitly bind to an exchange
-            bind = (ch) => ch
-                .then((ch) => {
-                    const fallbackQueue = queue === '' && assertion ?
-                        ch.assertQueue('', opts).then(({ queue: q }) => q) :
-                        Promise.resolve(queue);
+            bind = (ch) => {
+                const fallbackQueue = queue === '' && assertion ?
+                    ch.assertQueue('', opts).then(({ queue: q }) => q) :
+                    Promise.resolve(queue);
 
-                    return fallbackQueue.then((q) => ({ ch, queue: q }));
-                })
-                .then(({ ch, queue }) => {
-                    const bind = typeof binding === 'string' ?
-                        ch.bindQueue(queue, exchange, binding) :
-                        ch.bindQueue(queue, exchange, '', binding);
-                    return bind.then(() => ({ ch, queue }));
-                });
+                return fallbackQueue
+                    .then((q) => ({ ch, queue: q }))
+                    .then(({ ch, queue }) => {
+                        const bind = typeof binding === 'string' ?
+                            ch.bindQueue(queue, exchange, binding) :
+                            ch.bindQueue(queue, exchange, '', binding);
+                        return bind.then(() => ({ ch, queue }));
+                    });
+            };
         }
 
         // start consuming in the assertion phase.
         /** @param {EventEmitter} emitter */
         const consume = (emitter) =>
-            this._assert((ch) => bind(ch)
+            this._assert((ch) => ch
+                .then((ch) => qos(ch))
+                .then((ch) => bind(ch))
                 .then(({ ch, queue }) => this._consume(ch, queue, fn, options, emitter)));
 
         return consumers.create(consume);

--- a/lib/api.spec.js
+++ b/lib/api.spec.js
@@ -134,6 +134,20 @@ describe('api', () => {
                 assert.deepStrictEqual(ch.assertQueue.args[0], ['a.queue', TRANSIENT]);
             },
             after: (ch) => ch.deleteExchange('a.declared')
+        },
+        'specified prefetch count': {
+            do: (client) => {
+                const ctx = client.prefetch(3);
+                return ctx
+                    .subscribe('another.key', () => {}, { exclusive: true })
+                    .then(() => ctx);
+            },
+            assert: (ctx, ch) => {
+                assert.strictEqual(ctx.prefetch, 3);
+
+                assert.ok(ch.prefetch.calledOnce);
+                assert.deepStrictEqual(ch.prefetch.args[0], [3]);
+            }
         }
     };
 
@@ -141,7 +155,7 @@ describe('api', () => {
         it(`should associate ${name}`, async() => {
             if (test.before) await test.before(await client._asserted());
 
-            const ctx = test.do(client)._validateContext();
+            const ctx = (await test.do(client))._validateContext();
             const ch = await client._asserted();
             test.assert(ctx, ch);
 


### PR DESCRIPTION
Additional work is needed to allow users to modify channel-wise limits.

@openrm/dev 