### PR TITLE
update amqplib and types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -367,9 +367,9 @@
       "dev": true
     },
     "@types/amqplib": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.13.tgz",
-      "integrity": "sha512-0r8cJfUajAlcHxlJsZyqRrSAYzv+pJPsaAQjDC6e5rACi3AOIuR0AfevJG7NLvw3Qu4EGhf3KS/ECwd5cUAY2A==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.16.tgz",
+      "integrity": "sha512-M/D13gVboXAA07A6GX8df3H/Wew1CjfIceVasnVK5SiSB9PfRyPl8TKppVb/DeR1zIffToxOU5otDcoIsn2C6g==",
       "dev": true,
       "requires": {
         "@types/bluebird": "*",
@@ -377,9 +377,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.32",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.32.tgz",
-      "integrity": "sha512-dIOxFfI0C+jz89g6lQ+TqhGgPQ0MxSnh/E4xuC0blhFtyW269+mPG5QeLgbdwst/LvdP8o1y0o/Gz5EHXLec/g==",
+      "version": "3.5.33",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.33.tgz",
+      "integrity": "sha512-ndEo1xvnYeHxm7I/5sF6tBvnsA4Tdi3zj1keRKRs12SP+2ye2A27NDJ1B6PqkfMbGAcT+mqQVqbZRIrhfOp5PQ==",
       "dev": true
     },
     "@types/color-name": {
@@ -429,9 +429,9 @@
       }
     },
     "amqplib": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.5.tgz",
-      "integrity": "sha512-sWx1hbfHbyKMw6bXOK2k6+lHL8TESWxjAx5hG8fBtT7wcxoXNIsFxZMnFyBjxt3yL14vn7WqBDe5U6BGOadtLg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.6.0.tgz",
+      "integrity": "sha512-zXCh4jQ77TBZe1YtvZ1n7sUxnTjnNagpy8MVi2yc1ive239pS3iLwm4e4d5o4XZGx1BdTKQ/U0ZmaDU3c8MxYQ==",
       "requires": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.5.2",
@@ -2379,9 +2379,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
     },
     "readable-stream": {
       "version": "1.1.14",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
   },
   "homepage": "https://github.com/openrm/hato#readme",
   "dependencies": {
-    "amqplib": "^0.5.5",
+    "amqplib": "^0.6.0",
     "puid": "^1.0.7"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.5.13",
+    "@types/amqplib": "^0.5.16",
     "@types/node": "< 13",
     "eslint": "^6.8.0",
     "mocha": "^7.1.2",


### PR DESCRIPTION
@openrm/dev 

When running node 14, installing hato through npm would give a warning:

```
npm WARN notsup Unsupported engine for amqplib@0.5.6: wanted: {"node":">=0.8 <=12"} (current: {"node":"14.15.1","npm":"6.14.8"})
npm WARN notsup Not compatible with your version of node/npm: amqplib@0.5.6
```