### PR TITLE
Fix infinite loop when both current/provided prefetch = 0

### DIFF
--- a/plugins/defaults.js
+++ b/plugins/defaults.js
@@ -48,7 +48,7 @@ module.exports = class DefaultOptions extends Plugin {
 
         this.scopes[Scopes.API] = (base) => class extends base {
             consume(queue, fn, options) {
-                if (this._context.prefetch === 0) {
+                if (this._context.prefetch === 0 && prefetch > 0) {
                     return super.context({ prefetch }).consume(queue, fn, options);
                 } else {
                     return super.consume(queue, fn, options);


### PR DESCRIPTION
@openrm/dev 

It was causing an infinite loop when no option for the prefetch count was provided (which defaults to 0)