### PR TITLE
Add more infos in error logs for decoding failure

### DIFF
--- a/plugins/encoding.js
+++ b/plugins/encoding.js
@@ -26,7 +26,11 @@ module.exports = class extends Plugin {
                             '[AMQP:encoding] JSON deserialization failed with an exception.',
                             e.message,
                             'Value:',
-                            msg.content);
+                            msg.content,
+                            'Queue:',
+                            queue,
+                            'Properties:',
+                            msg.properties);
                     }
                     break;
                 default:


### PR DESCRIPTION
@openrm/dev I would like to try adding more infos in this warn log to help debugging a situation where the log is triggered. Currently the error log only states:

```
[AMQP:encoding] JSON deserialization failed with an exception. Unexpected end of JSON input Value: <Buffer >
```

With the properties (headers, correlationId, replyTo) I think it would be enough for developers to start investigating.

What do you think?