### PR TITLE
Add more info on TimeoutError (routing key)

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -14,8 +14,8 @@ module.exports.TimeoutError = class TimeoutError extends Error {
      * @constructor
      * @param {number} timeout
      */
-    constructor(timeout) {
-        super(`Operation timed out after ${timeout}ms`);
+    constructor(timeout, message) {
+        super(`Operation timed out after ${timeout}ms` + (message ? ` - ${message}` : ''));
         this.name = 'TimeoutError';
     }
 };

--- a/plugins/rpc/api.js
+++ b/plugins/rpc/api.js
@@ -35,7 +35,7 @@ function makeRpc(plugin, routingKey, msg, { timeout, ...options }) {
 
         if (timeout > 0) {
             const abort = () => {
-                reject(new TimeoutError(timeout));
+                reject(new TimeoutError(timeout, routingKey));
                 cleanup();
             };
             timer = setTimeout(abort, timeout);


### PR DESCRIPTION
@openrm/dev allow to add more information on timeout error, and provide the routing key in the RPC plugin  